### PR TITLE
Builds on multiple platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
              build_args: "type=slim"
              base: "ubuntu:focal"
     runs-on: ubuntu-latest
-    steps:        
+    steps:
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -53,6 +53,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
@@ -61,7 +64,7 @@ jobs:
           restore-keys: "${{ steps.prep.outputs.key }}-buildx-${{ github.sha }}"
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.docker_username }}
           password: ${{ secrets.docker_password }}
@@ -71,6 +74,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
+          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64
           tags: ${{ steps.prep.outputs.tags }}
           build-args: ${{ matrix.build_args }}
           cache-from: type=local,src=/tmp/.buildx-cache


### PR DESCRIPTION
- Add support for `linux/386`, `linux/arm/v7` and `linux/arm64`.
- Disable ipv6 in `gnupg` config while adding key servers. Fixes flaky behaviour.
- Pin Node.js 32 bit version to `12.16.3` as that is the last available `x86` build.
- Add workaround to install `Xdebug` across platforms.
- Minor clean up in workflow.